### PR TITLE
Width added to Offering Cards

### DIFF
--- a/src/components/landing/OfferingCard.jsx
+++ b/src/components/landing/OfferingCard.jsx
@@ -1,6 +1,6 @@
 const OfferingCard = ({ title, description, icon }) => {
   return (
-    <div className="h-full rounded-3xl p-8 bg-ai-blue-200 flex flex-col justify-between">
+    <div className="m-8 h-fit w-10/12 lg:w-2/5 xl:w-1/5 rounded-3xl p-8 bg-ai-blue-200 flex flex-col justify-between">
       <h3 className="text-white text-2xl text-center font-semibold">{title}</h3>
       <div className="flex justify-center items-center">{icon}</div>
       <p className="text-center text-ai-gray">{description}</p>

--- a/src/components/landing/OfferingCard.jsx
+++ b/src/components/landing/OfferingCard.jsx
@@ -1,6 +1,6 @@
 const OfferingCard = ({ title, description, icon }) => {
   return (
-    <div className="m-8 h-fit w-10/12 lg:w-2/5 xl:w-1/5 rounded-3xl p-8 bg-ai-blue-200 flex flex-col justify-between">
+    <div className="h-fit w-full  rounded-3xl p-8 bg-ai-blue-200 flex flex-col justify-between">
       <h3 className="text-white text-2xl text-center font-semibold">{title}</h3>
       <div className="flex justify-center items-center">{icon}</div>
       <p className="text-center text-ai-gray">{description}</p>

--- a/src/components/landing/OfferingCards.jsx
+++ b/src/components/landing/OfferingCards.jsx
@@ -5,8 +5,8 @@ const OfferingCards = () => {
   return (
     <section className="h-fit p-4">
       <p className="text-4xl text-ai-blue-500 text-center m-8">We Offer...</p>
-      <div className="flex justify-center h-full">
-        <div className="w-full flex flex-col lg:flex-row items-center flex-wrap justify-around space-y-4 lg:space-y-0">
+      <div className="flex justify-center">
+        <div className="w-full flex flex-col p-4 items-start space-y-4 lg:space-y-0 lg:grid lg:grid-cols-2 xl:grid-cols-3 gap-8 justify-center">
           {offerings.map((offering, index) => (
             <OfferingCard
               key={index}

--- a/src/components/landing/OfferingCards.jsx
+++ b/src/components/landing/OfferingCards.jsx
@@ -3,10 +3,10 @@ import { offerings } from "@/data/Offerings";
 
 const OfferingCards = () => {
   return (
-    <section className="p-4">
+    <section className="h-fit p-4">
       <p className="text-4xl text-ai-blue-500 text-center m-8">We Offer...</p>
-      <div className="flex justify-center">
-        <div className="inline-grid grid-cols-1 md:grid-cols-3 gap-8 w-auto place-items-center">
+      <div className="flex justify-center h-full">
+        <div className="w-full flex flex-col lg:flex-row items-center flex-wrap justify-around space-y-4 lg:space-y-0">
           {offerings.map((offering, index) => (
             <OfferingCard
               key={index}


### PR DESCRIPTION
IPhone 14 Pro Display:
![Screenshot 2024-07-31 154509](https://github.com/user-attachments/assets/2c7c29c9-5fce-4a69-b7bc-95ff75be0cb1)

IPad Pro Display:
![Screenshot 2024-07-31 154521](https://github.com/user-attachments/assets/e1312c60-d58e-4edb-8a79-3fbb473823d7)

Laptop Display: Based on a QHD Display
![Screenshot 2024-07-31 154542](https://github.com/user-attachments/assets/7adcc3e0-5a34-4698-a815-a5e49d7ba586)

- Edited some styles in both the OfferingCard.jsx and OfferingCards.jsx file
- Added some reponsive design based on different screen sizes 
-  Added w-full to card so it can take up the whole width of mobile phone or its "card" in grid display (1024 px and up)
-  Closes #55 