### PR TITLE
Added gap between the title and subtitle

### DIFF
--- a/src/components/landing/Introduction.jsx
+++ b/src/components/landing/Introduction.jsx
@@ -7,8 +7,8 @@ const Introduction = () => {
     <div className="pt-8 flex items-stretch justify-between bg-white drop-shadow-xl">
       <Image src={circuitImage} alt="Left Circuit Image" className="w-1/4" />
 
-      <div className="w-1/2 flex flex-col items-center justify-center gap-y-4">
-        <div className="flex flex-col items-center justify-center">
+      <div className="w-1/2 flex flex-col items-center justify-center gap-y-5">
+        <div className="flex flex-col items-center justify-center gap-y-4">
           <p className="whitespace-nowrap text-4xl sm:text-5xl md:text-6xl lg:text-7xl text-black">
             AI @ UCR
           </p>


### PR DESCRIPTION
<img width="1470" alt="Screenshot 2024-08-05 at 8 32 17 AM" src="https://github.com/user-attachments/assets/a23685e4-2368-4da6-b51a-28d0b3bae336">
<img width="1470" alt="Screenshot 2024-08-05 at 8 32 48 AM" src="https://github.com/user-attachments/assets/e48f1e8e-3247-4cc1-a158-713a1dfc587c">
<img width="1469" alt="Screenshot 2024-08-05 at 8 33 12 AM" src="https://github.com/user-attachments/assets/dbbe0f1a-db23-40ab-8d19-e66e2557471a">

Created gap between title and subtitle. Let me know if I need to adjust the values.