### PR TITLE
Added Constant Height to Offering Cards

### DIFF
--- a/src/components/landing/OfferingCard.jsx
+++ b/src/components/landing/OfferingCard.jsx
@@ -1,8 +1,8 @@
 const OfferingCard = ({ title, description, icon }) => {
   return (
-    <div className="h-fit w-full  rounded-3xl p-8 bg-ai-blue-200 flex flex-col justify-between">
+    <div className="rounded-3xl p-8 bg-ai-blue-200 flex flex-col justify-between h-full">
       <h3 className="text-white text-2xl text-center font-semibold">{title}</h3>
-      <div className="flex justify-center items-center">{icon}</div>
+      <div className="flex justify-center items-center mb-4">{icon}</div>
       <p className="text-center text-ai-gray">{description}</p>
     </div>
   );

--- a/src/components/landing/OfferingCards.jsx
+++ b/src/components/landing/OfferingCards.jsx
@@ -3,10 +3,10 @@ import { offerings } from "@/data/Offerings";
 
 const OfferingCards = () => {
   return (
-    <section className="h-fit p-4">
+    <section className="p-4">
       <p className="text-4xl text-ai-blue-500 text-center m-8">We Offer...</p>
       <div className="flex justify-center">
-        <div className="w-full flex flex-col p-4 items-start space-y-4 lg:space-y-0 lg:grid lg:grid-cols-2 xl:grid-cols-3 gap-8 justify-center">
+        <div className="w-full p-4 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-2 auto-rows-fr xl:grid-cols-3 ">
           {offerings.map((offering, index) => (
             <OfferingCard
               key={index}


### PR DESCRIPTION
IPhone 14 Pro Screen:
![Screenshot 2024-08-07 191919](https://github.com/user-attachments/assets/82fbe5c1-e54c-450a-a3df-c4aba15c6c9e)

IPad Pro Screen:
![Screenshot 2024-08-07 191932](https://github.com/user-attachments/assets/e9773079-aa58-4780-98fb-622d894f4a42)

Laptop Screen (QHD Resoultion) Screen:
![Screenshot 2024-08-07 191945](https://github.com/user-attachments/assets/38116950-d009-4234-ace4-cb7b292d46bd)

- Edited the style so that the height of the cards can match the height of the tallest card (Verified using the google html/css inspect tool and saw all cards matched heights)
- Took of the tailwind classes that uses h-fit or w-fit
- Closes #68 