### PR TITLE
Made Calendar Wider

### DIFF
--- a/src/components/calendar/Calendar.jsx
+++ b/src/components/calendar/Calendar.jsx
@@ -77,7 +77,7 @@ const CalendarEvent = () => {
           whileInView="show"
           viewport={{ once: true, amount: 0.1 }}
         >
-          <div className="flex justify-center h-[90vh] sm:h-60[vh] w-full font-righteous relative">
+          <div className="flex justify-center lg:h-[90vh] h-[60vh] w-full font-righteous relative">
             <Calendar
               date={date}
               className="w-full m-0 p-0 text-md md:text-2xl flex justify-center overflow-hidden"

--- a/src/components/calendar/Calendar.jsx
+++ b/src/components/calendar/Calendar.jsx
@@ -68,7 +68,7 @@ const CalendarEvent = () => {
 
   return (
     <div className="w-full flex flex-col justify-center items-center">
-      <section className="md:w-1/2 w-2/3 flex justify-center items-center flex-col mt-[2vh]">
+      <section className="md:w-10/12 w-full flex justify-center items-center flex-col mt-[2vh]">
         <motion.div
           className="w-full flex justify-center items-center"
           variants={animation}


### PR DESCRIPTION
IPhone 14 Pro Display:
![Screenshot 2024-08-19 120000](https://github.com/user-attachments/assets/7f5a7e9e-6f08-4738-a654-080a898d7636)

IPad Pro Display:
![Screenshot 2024-08-19 115946](https://github.com/user-attachments/assets/eb99acef-cbdc-4604-8fac-f15e816f786a)

QHD Laptop Display: 
![Screenshot 2024-08-19 115918](https://github.com/user-attachments/assets/325f4abe-7e77-4fd6-9f52-7b3673907d65)

- Edit the parent element so that the calendar tag since it matches the width of the parent
- Calendar can now grow to whole screen on mobile and ~90% of the screen width on tablet or wider screens
- Closes #93 