### PR TITLE
Made the calendar days small and aligned on the right

### DIFF
--- a/src/components/calendar/index.css
+++ b/src/components/calendar/index.css
@@ -41,7 +41,20 @@
 }
 
 .rbc-date-cell {
-  text-align: center;
+  text-align: right;
+  font-size: x-small;
+}
+
+@media only screen and (min-width: 1024px) {
+  .rbc-date-cell {
+    font-size: small;
+  }
+}
+
+@media only screen and (min-width: 1536px) {
+  .rbc-date-cell {
+    font-size: large;
+  }
 }
 
 .rbc-row-segment {


### PR DESCRIPTION
4K Monitor
![Screenshot 2024-08-20 at 10 44 58 AM](https://github.com/user-attachments/assets/bb371fd2-04a1-4a59-8ded-18efba83d500)

Laptop
![Screenshot 2024-08-20 at 10 45 33 AM](https://github.com/user-attachments/assets/86ed7524-9ded-4b1f-bea2-f186f3b34ff7)

iPad Air
![Screenshot 2024-08-20 at 10 46 12 AM](https://github.com/user-attachments/assets/6876d6e6-1a95-4d01-bf0e-4b100c57853b)

Mobile
![Screenshot 2024-08-20 at 10 46 38 AM](https://github.com/user-attachments/assets/508d85cf-6ff1-4ab7-b744-1ba1b754f1e6)

- Styled calendar days to the right and made the font size responsive
- Closes #82 
