### PR TITLE
Fixed mobile text size for information card

### DIFF
--- a/src/components/landing/Information.jsx
+++ b/src/components/landing/Information.jsx
@@ -14,7 +14,7 @@ const Information = () => {
             />
           </div>
           <div className="w-full md:w-7/12 px-4">
-            <p className="text-xl md:text-4xl leading-tight text-center my-8">
+            <p className="text-md md:text-4xl leading-tight text-center my-8">
               AI at UCR is the hub for all things Artificial Intelligence. We
               are committed to introducing AI and ML enthusiasts to the wider
               horizons of this evolving field.


### PR DESCRIPTION
- Changed text size for mobile devices from xl to medium.
- Closes #87 
![Image 8-20-24 at 10 49 PM](https://github.com/user-attachments/assets/8c4e01ba-2dcc-4769-87f4-7a0f157836c3)
