### PR TITLE
Made information text smaller on landing page

### DIFF
--- a/src/components/landing/Information.jsx
+++ b/src/components/landing/Information.jsx
@@ -14,7 +14,7 @@ const Information = () => {
             />
           </div>
           <div className="w-full md:w-7/12 px-4">
-            <p className="text-xl md:text-4xl leading-tight text-center my-8">
+            <p className="text-xs sm:text-md md:text-xl xl:text-4xl leading-tight text-center my-8">
               AI at UCR is the hub for all things Artificial Intelligence. We
               are committed to introducing AI and ML enthusiasts to the wider
               horizons of this evolving field.

--- a/src/components/landing/Information.jsx
+++ b/src/components/landing/Information.jsx
@@ -14,7 +14,7 @@ const Information = () => {
             />
           </div>
           <div className="w-full md:w-7/12 px-4">
-            <p className="text-xs sm:text-md md:text-xl xl:text-4xl leading-tight text-center my-8">
+            <p className="text-md md:text-4xl leading-tight text-center my-8">
               AI at UCR is the hub for all things Artificial Intelligence. We
               are committed to introducing AI and ML enthusiasts to the wider
               horizons of this evolving field.


### PR DESCRIPTION
iPhone 12 Pro
![Screenshot 2024-08-24 at 3 12 01 PM](https://github.com/user-attachments/assets/b957573d-4c7d-4c38-8979-75b4e4a1f9c5)

- Made information text smaller in mobile view (from text-xl to text-md)
- Closes #101 

