### PR TITLE
Offering Card Update

### DIFF
--- a/src/components/landing/OfferingCard.jsx
+++ b/src/components/landing/OfferingCard.jsx
@@ -1,6 +1,8 @@
-const OfferingCard = ({ title, description, icon }) => {
+const OfferingCard = ({ title, description, icon, column }) => {
   return (
-    <div className="rounded-3xl p-8 bg-ai-blue-200 flex flex-col justify-between h-full">
+    <div
+      className={`rounded-3xl p-8 bg-ai-blue-200 flex flex-col justify-between h-full ${column}`}
+    >
       <h3 className="text-white text-2xl text-center font-semibold font-montserrat">
         {title}
       </h3>

--- a/src/components/landing/OfferingCards.jsx
+++ b/src/components/landing/OfferingCards.jsx
@@ -15,6 +15,7 @@ const OfferingCards = () => {
               title={offering.title}
               icon={offering.icon}
               description={offering.description}
+              column={offering.column}
             />
           ))}
         </div>

--- a/src/data/Offerings.js
+++ b/src/data/Offerings.js
@@ -27,5 +27,6 @@ export const offerings = [
     description:
       "Stay informed with the most recent developments, breakthroughs, and job opportunities in the AI realm.",
     icon: <LiaNewspaperSolid className="text-5xl text-ai-blue-500" />,
+    column: "xl:col-start-2 xl:col-end-3",
   },
 ];


### PR DESCRIPTION
IPhone 14 Pro Display:
![Screenshot 2024-08-31 084350](https://github.com/user-attachments/assets/5fe51f9e-53a1-4bed-84af-f7fbd5dc4472)

IPad Air Display:
![Screenshot 2024-08-31 084411](https://github.com/user-attachments/assets/ded0d60f-b34a-4b76-b4e3-565431be3f79)

HD 1440px laptop:
![Screenshot 2024-08-27 110419](https://github.com/user-attachments/assets/ab4cc2ae-2f99-419e-80ea-1b2cb26ed966)

- Changed OfferingCard.jsx, OfferingCards.jsx and offering.js to help center the fourth card on large displays
- Added a column variable in OfferingCard so that you can apply certain tailwind configs to specific cards by entering them in offerings.js
-  closes #109 