### PR TITLE
Fixed introduction component grid lines and button

### DIFF
--- a/src/components/landing/Introduction.jsx
+++ b/src/components/landing/Introduction.jsx
@@ -4,23 +4,29 @@ import { TiArrowSortedDown } from "react-icons/ti";
 
 const Introduction = () => {
   return (
-    <div className="pt-8 flex items-stretch justify-between bg-white drop-shadow-xl">
-      <Image src={circuitImage} alt="Left Circuit Image" className="w-1/4" />
+    <div className="pt-8 flex justify-between bg-white drop-shadow-xl">
+      <Image
+        src={circuitImage}
+        alt="Left Circuit Image"
+        className="w-1/3 sm:w-1/4"
+      />
 
-      <div className="w-1/2 flex flex-col items-center justify-center gap-y-5">
-        <div className="flex flex-col items-center justify-center gap-y-4">
+      <div className="w-1/3 sm:w-1/2 flex flex-col items-center justify-center gap-y-5 lg:gap-y-8">
+        <div className="flex flex-col items-center justify-center gap-y-1 sm:gap-y-2 lg:gap-y-4">
           <p className="whitespace-nowrap text-4xl sm:text-5xl md:text-6xl lg:text-7xl text-black font-montserrat font-semibold">
             AI @ UCR
           </p>
-          <p className="whitespace-nowrap text-xs sm:text-sm md:text-lg lg:text-xl text-black font-hubbali">
+          <p className="whitespace-nowrap text-xs sm:text-lg md:text-xl lg:text-2xl text-black font-hubbali">
             Empowering the Future of Tech
           </p>
         </div>
 
         <div className="flex items-center justify-center aspect-square rounded-full">
-          <button className="flex shrink-0 rounded-full w-full h-full justify-center relative p-2 md:p-3 xl:p-4 2xl:p-5 text-xs md:text-md lg:text-xl text-white bg-ai-blue-500 font-hubbali">
-            Learn <br /> More
-            <div className="absolute inset-x-0 bottom-0 flex justify-center">
+          <button className="flex shrink-0 rounded-full w-full h-full justify-center relative p-2 sm:p-3 lg:p-4 text-xs md:text-md lg:text-xl text-white bg-ai-blue-500 font-hubbali">
+            <p className="pt-1 leading-none">
+              LEARN <br /> MORE
+            </p>
+            <div className="absolute inset-x-0 bottom-0.5 sm:bottom-1.5 flex justify-center">
               <TiArrowSortedDown className="text-xs md:text-md lg:text-xl text-white" />
             </div>
           </button>
@@ -30,7 +36,7 @@ const Introduction = () => {
       <Image
         src={circuitImage}
         alt="Right Circuit Image"
-        className="w-1/4 scale-x-[-1]"
+        className="w-1/3 sm:w-1/4 scale-x-[-1]"
       />
     </div>
   );


### PR DESCRIPTION
iPhone SE
![Screenshot 2024-08-30 at 3 45 20 PM](https://github.com/user-attachments/assets/9efae311-ef61-4a70-b33a-8cd86dff9c93)

iPhone 14 Pro Max
![Screenshot 2024-08-30 at 3 45 02 PM](https://github.com/user-attachments/assets/7693ea79-d620-44b1-80fa-c519a6ad0f6c)

iPad Mini
![Screenshot 2024-08-30 at 3 44 30 PM](https://github.com/user-attachments/assets/f16dc929-ed92-47e6-b47e-a9c36d933038)

iPad Pro
![Screenshot 2024-08-30 at 3 43 54 PM](https://github.com/user-attachments/assets/68248d59-caf9-414b-a672-02311dc611b4)

- Changed the scaling of grid lines images and "Learn More" button of the introduction component
- Closes #104 
